### PR TITLE
creates a '/ext/elife-metrics' if /ext exists.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-elifeFormula('elife-metrics', '/srv/elife-metrics', null, ['s2004'])
+elifeFormula('elife-metrics', '/srv/elife-metrics')

--- a/salt/elife-metrics/init.sls
+++ b/salt/elife-metrics/init.sls
@@ -93,12 +93,24 @@ ubr-app-db-backup:
 # configure
 # 
 
+# bit of a hack, the app will try to create this dir itself if it detects /ext exists to write in.
+# and while /ext might exist, it might not be writeable by the app. create it here to prevent a nuisance.
+elife-metrics-ext-vol-dir:
+    file.directory:
+        - name: /ext/elife-metrics
+        - makedirs: True
+        - user: {{ deploy_user }}
+        - dir_mode: 755
+        - onlyif:
+            - test -d /ext
+
 configure-elife-metrics:
     cmd.run:
         - runas: {{ deploy_user }}
         - cwd: /srv/elife-metrics/
         - name: ./install.sh && ./manage.sh collectstatic --noinput
         - require:
+            - file: elife-metrics-ext-vol-dir
             - install-elife-metrics
             - file: cfg-file
             - file: elife-metrics-log-file


### PR DESCRIPTION
prevents an app bug